### PR TITLE
Do not crash if path is missing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,11 @@ fn proxy_dst(dst: &Uri, proxy: &Uri) -> io::Result<Uri> {
                 .ok_or_else(|| io_err(format!("proxy uri missing host: {}", proxy)))?
                 .clone(),
         )
-        .path_and_query(dst.path_and_query().unwrap().clone())
+        .path_and_query(
+            dst.path_and_query()
+                .ok_or_else(|| io_err(format!("dst uri missing path: {}", proxy)))?
+                .clone(),
+        )
         .build()
         .map_err(|err| io_err(format!("other error: {}", err)))
 }


### PR DESCRIPTION
Do not crash if path is missing

This can happen e.g. when using this with force connect and http2 protocol like in grpc.